### PR TITLE
issue 4 file heading should not specify pin 13

### DIFF
--- a/MorseCodeBlink.cpp
+++ b/MorseCodeBlink.cpp
@@ -2,7 +2,7 @@
     Morse Code Blink library for Arduino Uno
 
     This library contains LED blink sequences for Morse Code on Arduino boards.
-    By default, this library works with pin 13 of an Arduino Uno.
+    By default, this library works with a given output pin of an Arduino Uno.
 
     Published under GNU General Public License v3
 

--- a/MorseCodeBlink.h
+++ b/MorseCodeBlink.h
@@ -2,7 +2,7 @@
     Morse Code Blink library for Arduino Uno
 
     This library contains LED blink sequences for Morse Code on Arduino boards.
-    By default, this library works with pin 13 of an Arduino Uno.
+    By default, this library works with a given output pin of an Arduino Uno.
 
     Published under GNU General Public License v3
 


### PR DESCRIPTION
Update file heading to reflect user control over pin.

Because the user can set the pin out to use, the heading should
no longer specify pin 13.

Resolves: #4